### PR TITLE
Support multiple substrate urls

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -45,6 +45,14 @@ func NewPool(url ...string) (Pool, error) {
 		return nil, fmt.Errorf("at least one url is required")
 	}
 
+	// the shuffle is needed so if one endpoints fails, and the next one
+	// is tried, we will end up moving all connections to the "next" endpoint
+	// which will get overloaded. Instead the shuffle helps to make the "next"
+	// different for reach instace of the pool.
+	rand.Shuffle(len(url), func(i, j int) {
+		url[i], url[j] = url[j], url[i]
+	})
+
 	return &poolImpl{
 		urls: url,
 		r:    rand.Intn(len(url)), // start with random url, then roundrobin

--- a/impl.go
+++ b/impl.go
@@ -76,7 +76,9 @@ func (p *poolImpl) Get() (Conn, Meta, error) {
 
 	for {
 		if p.cl == nil {
-			cl, err := gsrpc.NewSubstrateAPI(p.endpoint())
+			endpoint := p.endpoint()
+			log.Debug().Str("url", endpoint).Msg("connecting")
+			cl, err := gsrpc.NewSubstrateAPI(endpoint)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -85,9 +87,9 @@ func (p *poolImpl) Get() (Conn, Meta, error) {
 		meta, err := p.cl.RPC.State.GetMetadataLatest()
 		if errors.Is(err, net.ErrClosed) {
 			p.cl = nil
-			log.Debug().Msg("reconnecting")
 			continue
 		} else if err != nil {
+			p.cl = nil
 			return nil, nil, err
 		}
 


### PR DESCRIPTION
On start one url is picked at random, then if the
connection failed, they are tried in a roundrobin
fashion